### PR TITLE
refactor(taiko): refactor some codes

### DIFF
--- a/clients/taiko-client/start.sh
+++ b/clients/taiko-client/start.sh
@@ -103,7 +103,7 @@ case $HIVE_TAIKO_ROLE in
   FLAGS="$FLAGS --l1.proposerPrivKey=$HIVE_TAIKO_PROPOSER_PRIVATE_KEY"
   FLAGS="$FLAGS --l2.suggestedFeeRecipient=$HIVE_TAIKO_SUGGESTED_FEE_RECIPIENT"
   FLAGS="$FLAGS --proposeInterval=$HIVE_TAIKO_PROPOSE_INTERVAL"
-  FLAGS="$FLAGS --verbosity 4"
+  FLAGS="$FLAGS --verbosity 3"
   if [ "$HIVE_TAIKO_PRODUCE_INVALID_BLOCKS_INTERVAL" != "" ]; then
     FLAGS="$FLAGS --produceInvalidBlocks"
     FLAGS="$FLAGS --produceInvalidBlocksInterval=$HIVE_TAIKO_PRODUCE_INVALID_BLOCKS_INTERVAL"

--- a/clients/taiko-protocol/deploy.sh
+++ b/clients/taiko-protocol/deploy.sh
@@ -3,21 +3,20 @@
 # workspace dir
 cd /taiko-mono/packages/protocol
 
-echo "$HIVE_TAIKO_MAINNET_URL"
-echo "$HIVE_TAIKO_PRIVATE_KEY"
-echo "$HIVE_TAIKO_L1_DEPLOYER_ADDRESS"
-echo "$HIVE_TAIKO_L2_GENESIS_BLOCK_HASH"
-echo "$HIVE_TAIKO_L2_CHAIN_ID"
-echo "$HIVE_TAIKO_L2_ROLLUP_ADDRESS"
+echo HIVE_TAIKO_MAINNET_URL: "$HIVE_TAIKO_MAINNET_URL"
+echo HIVE_TAIKO_PRIVATE_KEY: "$HIVE_TAIKO_PRIVATE_KEY"
 
 export MAINNET_URL="$HIVE_TAIKO_MAINNET_URL"
 export PRIVATE_KEY="$HIVE_TAIKO_PRIVATE_KEY"
 
-npx hardhat deploy_L1 \
-  --network mainnet \
-  --dao-vault "$HIVE_TAIKO_L1_DEPLOYER_ADDRESS" \
-  --team-vault "$HIVE_TAIKO_L1_DEPLOYER_ADDRESS" \
-  --l2-genesis-block-hash "$HIVE_TAIKO_L2_GENESIS_BLOCK_HASH" \
-  --l2-chain-id "$HIVE_TAIKO_L2_CHAIN_ID" \
-  --v1-taiko-l2 "$HIVE_TAIKO_L2_ROLLUP_ADDRESS" \
-  --confirmations 1
+FLAGS="--network mainnet"
+FLAGS="$FLAGS --dao-vault $HIVE_TAIKO_L1_DEPLOYER_ADDRESS"
+FLAGS="$FLAGS --team-vault $HIVE_TAIKO_L1_DEPLOYER_ADDRESS"
+FLAGS="$FLAGS --l2-genesis-block-hash $HIVE_TAIKO_L2_GENESIS_BLOCK_HASH"
+FLAGS="$FLAGS --l2-chain-id $HIVE_TAIKO_L2_CHAIN_ID"
+FLAGS="$FLAGS --taiko-l2 $HIVE_TAIKO_L2_ROLLUP_ADDRESS"
+FLAGS="$FLAGS --confirmations 1"
+
+echo "Deploy L1 rollup contacts with flags $FLAGS"
+
+npx hardhat deploy_L1 $FLAGS

--- a/simulators/taiko/ops/main.go
+++ b/simulators/taiko/ops/main.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/hive/hivesim"
 	"github.com/ethereum/hive/taiko"
@@ -57,7 +58,8 @@ func launchTest(t *hivesim.T) {
 // wait the a L2 transaction be proposed and proved as a L2 block.
 func firstVerifiedL2Block(t *hivesim.T, ctx context.Context, d *taiko.Devnet) func(t *hivesim.T) {
 	return func(t *hivesim.T) {
-		taiko.WaitProveEvent(ctx, t, d.GetL1ELNode(0), []*big.Int{big.NewInt(1)})
+		blockHash := taiko.GetBlockHashByNumber(ctx, t, d.GetL2ELNode(0).EthClient(), common.Big1, true)
+		taiko.WaitProveEvent(ctx, t, d.GetL1ELNode(0), blockHash)
 	}
 }
 
@@ -77,7 +79,7 @@ func syncAllFromL1(t *hivesim.T, ctx context.Context, d *taiko.Devnet) func(t *h
 		defer cancel()
 		l2 := d.AddL2ELNode(ctx, 0, false)
 		d.AddDriverNode(ctx, d.GetL1ELNode(0), l2, false)
-		taiko.WaitBlock(ctx, t, l2.EthClient(), 1)
+		taiko.WaitBlock(ctx, t, l2.EthClient(), common.Big1)
 	}
 }
 

--- a/simulators/taiko/ops/main.go
+++ b/simulators/taiko/ops/main.go
@@ -5,22 +5,17 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/hive/hivesim"
 	"github.com/ethereum/hive/taiko"
-	"github.com/stretchr/testify/require"
-	"github.com/taikoxyz/taiko-client/bindings"
 )
 
 var allTests = []*taiko.TestSpec{
-	{Name: "first L2", Description: "generate first verified L2 block", Run: firstVerifiedL2Block},
-	{Name: "invalid txList", Description: "get invalid txList from L2-engine", Run: genInvalidL2Block},
-	{Name: "L1 reorg", Description: "driver handle L1 re-org", Run: driverHandleL1Reorg},
-	{Name: "sync from L1", Description: "completes sync purely from L1 data to generate L2 block", Run: syncAllFromL1},
-	{Name: "sync by p2p", Description: "L2 chain head determined by L1, but sync block completes through taiko-geth P2P", Run: syncByP2P},
-	{Name: "propose 2048 blocks at once", Description: "", Run: testPropose2048Blocks},
+	// {Name: "invalid txList", Description: "get invalid txList from L2-engine", Run: genInvalidL2Block},
+	// {Name: "L1 reorg", Description: "driver handle L1 re-org", Run: driverHandleL1Reorg},
+	// {},
+	// {Name: "sync by p2p", Description: "L2 chain head determined by L1, but sync block completes through taiko-geth P2P", Run: syncByP2P},
+	// {Name: "propose 2048 blocks at once", Description: "", Run: testPropose2048Blocks},
 }
 
 func main() {
@@ -31,55 +26,38 @@ func main() {
 	suit.Add(&hivesim.TestSpec{
 		Name:        "single node net ops",
 		Description: "test ops on single node net",
-		Run:         runAllTests(allTests),
+		Run:         launchTest,
 	})
 
 	sim := hivesim.New()
 	hivesim.MustRun(sim, suit)
 }
 
-func runAllTests(tests []*taiko.TestSpec) func(t *hivesim.T) {
-	return func(t *hivesim.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-		defer cancel()
-		// generate a L2 transaction
-		d := taiko.NewDevnet(ctx, t)
-		d.L2Vault.CreateAccount(ctx, d.GetL2ELNode(0).EthClient(), big.NewInt(params.Ether))
+func launchTest(t *hivesim.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 
-		taiko.RunTests(ctx, t, &taiko.RunTestsParams{
-			Devnet:      d,
-			Tests:       tests,
-			Concurrency: 10,
-		})
-	}
+	// generate the first L2 transaction
+	d := taiko.NewDevnet(ctx, t)
+	d.L2Vault.CreateAccount(ctx, d.GetL2ELNode(0).EthClient(), big.NewInt(params.Ether))
+
+	t.Run(hivesim.TestSpec{
+		Name:        "firstVerifiedL2Block",
+		Description: "watch prove event of the first L2 block on L1",
+		Run:         firstVerifiedL2Block(t, ctx, d),
+	})
+
+	t.Run(hivesim.TestSpec{
+		Name:        "sync from L1",
+		Description: "completes sync purely from L1 data to generate L2 block",
+		Run:         syncAllFromL1(t, ctx, d),
+	})
 }
 
 // wait the a L2 transaction be proposed and proved as a L2 block.
-func firstVerifiedL2Block(t *hivesim.T, env *taiko.TestEnv) {
-	d := env.DevNet
-	taikoL1, err := d.GetL1ELNode(0).L1TaikoClient()
-	require.Nil(t, err)
-	start := uint64(0)
-	opt := &bind.WatchOpts{Start: &start, Context: env.Context}
-	eventCh := make(chan *bindings.TaikoL1ClientBlockProven)
-	sub, err := taikoL1.WatchBlockProven(opt, eventCh, []*big.Int{big.NewInt(1)})
-	defer sub.Unsubscribe()
-	if err != nil {
-		t.Fatal("Failed to watch prove event", err)
-	}
-	for {
-		select {
-		case err := <-sub.Err():
-			t.Fatal("Failed to watch prove event", err)
-		case e := <-eventCh:
-			if e.Id.Uint64() == 1 {
-				t.Log("all success")
-				return
-			}
-		case <-env.Context.Done():
-			t.Log("test is finished before watch proved event")
-			return
-		}
+func firstVerifiedL2Block(t *hivesim.T, ctx context.Context, d *taiko.Devnet) func(t *hivesim.T) {
+	return func(t *hivesim.T) {
+		taiko.WaitProveEvent(ctx, t, d.GetL1ELNode(0), []*big.Int{big.NewInt(1)})
 	}
 }
 
@@ -93,37 +71,22 @@ func driverHandleL1Reorg(t *hivesim.T, env *taiko.TestEnv) {
 
 // Start a new driver and taiko-geth, the driver is connected to L1 that already has a propose block,
 // and the driver will synchronize and process the propose event on L1 to let taiko-geth generate a new block.
-func syncAllFromL1(t *hivesim.T, env *taiko.TestEnv) {
-	d := env.DevNet
-	l2 := d.AddL2ELNode(env.Context, 0, false)
-	d.AddDriverNode(env.Context, d.GetL1ELNode(0), l2)
-
-	ch := make(chan *types.Header)
-	cli, err := l2.RawRpcClient()
-	require.NoError(t, err)
-	sub, err := cli.SubscribeNewHead(env.Context, ch)
-	require.NoError(t, err)
-	defer sub.Unsubscribe()
-	for {
-		for {
-			select {
-			case h := <-ch:
-				if h.Number.Uint64() > 0 {
-					return
-				}
-				return
-			case err := <-sub.Err():
-				require.NoError(t, err)
-			case <-env.Context.Done():
-				t.Fatalf("program close before test finish")
-			}
-		}
+func syncAllFromL1(t *hivesim.T, ctx context.Context, d *taiko.Devnet) func(t *hivesim.T) {
+	return func(t *hivesim.T) {
+		ctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+		l2 := d.AddL2ELNode(ctx, 0, false)
+		d.AddDriverNode(ctx, d.GetL1ELNode(0), l2, false)
+		taiko.WaitBlock(ctx, t, l2.EthClient(), 1)
 	}
 }
 
-func syncByP2P(t *hivesim.T, env *taiko.TestEnv) {
-	// TODO
+func syncByP2P(t *hivesim.T, ctx context.Context, d *taiko.Devnet) func(t *hivesim.T) {
+	return func(t *hivesim.T) {
+
+	}
 }
+
 func testPropose2048Blocks(t *hivesim.T, env *taiko.TestEnv) {
 	// TODO
 }

--- a/taiko/config.go
+++ b/taiko/config.go
@@ -38,7 +38,6 @@ var DefaultConfig = &Config{
 		RollupAddress:         common.HexToAddress("0x0000777700000000000000000000000000000001"),
 		BridgeAddress:         common.HexToAddress("0x0000777700000000000000000000000000000004"),
 		VaultAddress:          common.HexToAddress("0x0000777700000000000000000000000000000002"),
-		GenesisBlockHash:      common.HexToHash("0xe76a69b167bb118c79ed3be2dd2073b300acd4861e31a603c7677186b42372a5"),
 		TestERC20Address:      common.HexToAddress("0x0000777700000000000000000000000000000005"),
 		Throwawayer:           deployAccount,
 
@@ -90,7 +89,6 @@ type L2Config struct {
 	RollupAddress         common.Address
 	BridgeAddress         common.Address
 	VaultAddress          common.Address
-	GenesisBlockHash      common.Hash
 	TestERC20Address      common.Address
 
 	ProduceInvalidBlocksInterval uint64

--- a/taiko/devnet.go
+++ b/taiko/devnet.go
@@ -74,7 +74,7 @@ func (d *Devnet) AddL1ELNode(ctx context.Context, Idx uint, l2 *ELNode, opts ...
 	n := &ELNode{d.t.StartClient(c.Name, opts...), d.c.L1.RollupAddress}
 	WaitELNodesUp(ctx, d.t, n, 10*time.Second)
 
-	l2GenesisHash := GetBlockHashByNumber(ctx, d.t, l2.EthClient(), common.Big0)
+	l2GenesisHash := GetBlockHashByNumber(ctx, d.t, l2.EthClient(), common.Big0, false)
 	d.deployL1Contracts(ctx, n, l2GenesisHash)
 
 	d.Lock()

--- a/taiko/envs.go
+++ b/taiko/envs.go
@@ -16,27 +16,26 @@ package taiko
 
 // taiko environment variables constants
 const (
-	// common
+	// hive common
 	envNetworkID    = "HIVE_NETWORK_ID"
 	envBootNode     = "HIVE_BOOTNODE"
 	envCliquePeriod = "HIVE_CLIQUE_PERIOD"
 	envNodeType     = "HIVE_NODETYPE"
 	envLogLevel     = "HIVE_LOGLEVEL"
 
-	// L1
+	// taiko common
+	envTaikoRole            = "HIVE_TAIKO_ROLE"
 	envTaikoL1ChainID       = "HIVE_TAIKO_L1_CHAIN_ID"
+	envTaikoJWTSecret       = "HIVE_TAIKO_JWT_SECRET"
 	envTaikoL1RPCEndpoint   = "HIVE_TAIKO_L1_RPC_ENDPOINT"
+	envTaikoL2RPCEndpoint   = "HIVE_TAIKO_L2_RPC_ENDPOINT"
 	envTaikoL1RollupAddress = "HIVE_TAIKO_L1_ROLLUP_ADDRESS"
-
-	// L2
-	envTaikoL2RPCEndpoint    = "HIVE_TAIKO_L2_RPC_ENDPOINT"
-	envTaikoL2EngineEndpoint = "HIVE_TAIKO_L2_ENGINE_ENDPOINT"
-	envTaikoL2RollupAddress  = "HIVE_TAIKO_L2_ROLLUP_ADDRESS"
-
-	envTaikoRole = "HIVE_TAIKO_ROLE"
+	envTaikoL2RollupAddress = "HIVE_TAIKO_L2_ROLLUP_ADDRESS"
 
 	// driver
+	envTaikoL2EngineEndpoint                = "HIVE_TAIKO_L2_ENGINE_ENDPOINT"
 	envTaikoThrowawayBlockBuilderPrivateKey = "HIVE_TAIKO_THROWAWAY_BLOCK_BUILDER_PRIVATE_KEY"
+	evnTaikoEnableL2P2P                     = "HIVE_TAIKO_ENABLE_L2_P2P"
 
 	// proposer
 	envTaikoProposeInterval              = "HIVE_TAIKO_PROPOSE_INTERVAL"
@@ -46,7 +45,6 @@ const (
 
 	// prover
 	envTaikoProverPrivateKey = "HIVE_TAIKO_PROVER_PRIVATE_KEY"
-	envTaikoJWTSecret        = "HIVE_TAIKO_JWT_SECRET"
 
 	// deployer
 	envTaikoL1DeployerAddress  = "HIVE_TAIKO_L1_DEPLOYER_ADDRESS"

--- a/taiko/nodes.go
+++ b/taiko/nodes.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/hive/hivesim"
+	"github.com/stretchr/testify/require"
 	"github.com/taikoxyz/taiko-client/bindings"
 )
 
@@ -45,28 +46,28 @@ func (e *ELNode) WsRpcEndpoint() string {
 	}
 }
 
-func (e *ELNode) RawRpcClient() (*ethclient.Client, error) {
-	return ethclient.Dial(e.WsRpcEndpoint())
+func (e *ELNode) RawRpcClient(t *hivesim.T) *ethclient.Client {
+	cli, err := ethclient.Dial(e.WsRpcEndpoint())
+	require.NoError(t, err)
+	return cli
 }
 
 func (e *ELNode) EthClient() *ethclient.Client {
 	return ethclient.NewClient(e.RPC())
 }
 
-func (e *ELNode) L1TaikoClient() (*bindings.TaikoL1Client, error) {
-	c, err := e.RawRpcClient()
-	if err != nil {
-		return nil, err
-	}
-	return bindings.NewTaikoL1Client(e.TaikoAddr, c)
+func (e *ELNode) L1TaikoClient(t *hivesim.T) *bindings.TaikoL1Client {
+	c := e.RawRpcClient(t)
+	cli, err := bindings.NewTaikoL1Client(e.TaikoAddr, c)
+	require.NoError(t, err)
+	return cli
 }
 
-func (e *ELNode) L2TaikoClient() (*bindings.V1TaikoL2Client, error) {
-	c, err := e.RawRpcClient()
-	if err != nil {
-		return nil, err
-	}
-	return bindings.NewV1TaikoL2Client(e.TaikoAddr, c)
+func (e *ELNode) L2TaikoClient(t *hivesim.T) *bindings.V1TaikoL2Client {
+	c := e.RawRpcClient(t)
+	cli, err := bindings.NewV1TaikoL2Client(e.TaikoAddr, c)
+	require.NoError(t, err)
+	return cli
 }
 
 type DriverNode struct {


### PR DESCRIPTION
- Sort environment variable descriptions by usage scenarios
- Rewrite the deploy.sh script and add log statements to check deployment parameters
- Extract the same code in the test case as a function in the taiko library
- L2GenesisBlockHash is no longer a configuration item, but obtained through the RPC interface
